### PR TITLE
ci: stop the node version renaming the lint check

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,21 +4,27 @@ on:
 
 jobs:
   lint:
+    # No matrix, on purpose. GitHub appends the matrix value to the job name, so
+    # a one-entry matrix called this check "Prettier & markdown linting (23)" and
+    # renamed it every time the version moved. The branch ruleset requires it by
+    # name, and it was still asking for "(20)" — a check nothing had produced
+    # since the bump, which is a merge that hangs rather than an error anyone
+    # sees. One version belongs here, written once, where renaming it is a
+    # deliberate act.
     name: Prettier & markdown linting
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        node-version: [23]
+    env:
+      NODE_VERSION: 23
     steps:
       - uses: actions/checkout@v7
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.10
         with:
           version: 10
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Refs #219

**Stacked on #221** — merge that first. Base here is `fix/golangci-v2-config`, so the diff is just the one commit. GitHub retargets this to `main` once #221 lands. It's stacked only because nothing in this repo can be committed until #221 fixes the hook, not because the changes are related.

GitHub appends the matrix value to a job's name. This job's matrix has exactly one entry, `node-version: [23]`, so the check reports as `Prettier & markdown linting (23)` and gets renamed every time that number moves.

The branch ruleset requires that check by name, and it's still asking for `(20)`. Nothing has produced `(20)` since the bump.

That's the failure mode worth fixing rather than just correcting the number in the ruleset. A required check that no longer exists doesn't fail — it never arrives, so the pull request sits waiting on it forever with no error to read. Nobody's hit it yet only because the ruleset is currently switched off, which is the other half of #219.

So the version goes in an env var and the job keeps one stable name. Changing Node is then a deliberate act that renames nothing.

I considered just editing the ruleset to say `(23)`. It's one click and it fixes today, but it leaves the trap armed for the next bump — and a hanging merge is a much worse thing to debug than a red tick.

## What still needs doing by hand

This PR only makes the name stable. Auto-merge stays broken until the ruleset is also updated to require `Prettier & markdown linting` (no suffix) and switched from `disabled` to `active`. That has to happen after this merges, because a ruleset can't require a check name until a run has produced it. I'll do both once this is in.