### PR TITLE
fix: stop merge commits duplicating every changelog entry

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # This repo rebases pull requests rather than merging them, and that is a
+      # requirement rather than a preference. GitHub writes the pull request
+      # title into the body of a merge commit, release-please pulls conventional
+      # commits out of a commit body as well as its subject, and so every change
+      # landed by a merge commit was listed twice in the changelog — once for the
+      # commit and once for the merge. Merge commits are switched off in the
+      # repository settings; there is no setting that leaves that body empty.
+      #
       # No `release-type` here on purpose. It's the manifest-less mode, and with
       # nothing recording the current version the action rebuilds history from
       # scratch — which is how it decided a repo sitting on v1.6.0 was due its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@
 
 ### Bug Fixes
 
-* give release-please the manifest it was missing ([23801dc](https://github.com/alrayyes/generictypealiasesdemo/commit/23801dc39c2c8fc2c90bc5f28d571746c9aa72c6))
 * give release-please the manifest it was missing ([cdb2e41](https://github.com/alrayyes/generictypealiasesdemo/commit/cdb2e41f2762e98be7543529280b15824e8aa1f9)), closes [#225](https://github.com/alrayyes/generictypealiasesdemo/issues/225)
-* migrate the golangci-lint config to v2 ([ab06d63](https://github.com/alrayyes/generictypealiasesdemo/commit/ab06d63563e2c76bcd00bb0eb0320f686964017a))
 * migrate the golangci-lint config to v2 ([aaa2155](https://github.com/alrayyes/generictypealiasesdemo/commit/aaa2155d24ef30e436acbab89f6fb3718087db33)), closes [#220](https://github.com/alrayyes/generictypealiasesdemo/issues/220)
 
 ## [1.6.0](https://github.com/alrayyes/generictypealiasesdemo/compare/v1.5.1...v1.6.0) (2025-02-13)


### PR DESCRIPTION
Every fix in the 1.6.1 section is listed twice. That's not release-please
being odd, it's the merge strategy: GitHub writes the pull request title into
the *body* of a merge commit, and release-please pulls conventional commits out
of a commit body as well as its subject, so each change gets counted once for
the real commit and once for the merge that landed it.

I went looking for a setting that leaves that body empty. There isn't one —
GitHub only accepts `PR_TITLE`+`PR_BODY`, `PR_TITLE`+`BLANK` and
`MERGE_MESSAGE`+`PR_TITLE`, and the first two just move the conventional commit
into the subject line where release-please still finds it. There's no
release-please config for it either; the body parsing came in with
[release-please#2358](https://github.com/googleapis/release-please/pull/2358)
and has no off switch.

So the only fix is to stop producing merge commits. Squash merges are what
release-please officially recommends, but they'd collapse each branch into one
commit and throw away the one-change-per-commit history. Rebase merges give the
same linear history and keep the commits, so that's what the repo is on now:
merge and squash are off in the settings, and Dependabot's auto-merge asks for
`--rebase`.

Two commits, in the order they should be read: the `ci:` one stops it happening
again, the `docs:` one removes the four lines it already produced. Neither is a
`fix:`, so this doesn't cut a release — a version bump for tidying a changelog
seemed like the wrong trade.

The surviving line of each duplicate pair is the real commit, which is also the
one carrying the issue it closed.

Closes #227
