### PR TITLE
ci: pin every action to a commit sha

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.0.0
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,16 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 1.24
       - name: Build

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7.2.3
+        uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -2,18 +2,22 @@ name: Hadolint
 
 on:
   push:
+
+permissions:
+  contents: read
+
 jobs:
   hadolint:
     name: Hadolint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7
-      - uses: hadolint/hadolint-action@v3.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
         with:
           dockerfile: docker/shellcheck/Dockerfile
-      - uses: hadolint/hadolint-action@v3.4.0
+      - uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
         with:
           dockerfile: docker/hadolint/Dockerfile
-      - uses: hadolint/hadolint-action@v3.4.0
+      - uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
         with:
           dockerfile: docker/golang/Dockerfile

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,9 @@ name: Linting
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     # No matrix, on purpose. GitHub appends the matrix value to the job name, so
@@ -19,7 +22,7 @@ jobs:
     name: Prettier & markdown linting
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,6 @@ jobs:
       # 1.0.0 release. release-please-config.json and .release-please-manifest.json
       # are picked up by default, and the manifest is the file to correct by
       # hand when a release goes wrong.
-      - uses: googleapis/release-please-action@v5.0.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,13 +2,17 @@ name: Shellcheck
 
 on:
   push:
+
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           ignore_names: import.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,18 +2,21 @@ name: Run tests and upload coverage
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests and collect coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
 
       - name: Install dependencies
         run: go mod download
@@ -22,6 +25,6 @@ jobs:
         run: go test ./... -coverprofile=coverage.txt
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Second of six on #229.

Every action here was on a tag, and a tag is a mutable pointer. Whoever owns the
action can move `v7` wherever they like and this repo picks it up on the next
run with nothing in the diff. `ludeeus/action-shellcheck@master` was the extreme
of it: someone else's default branch, executing in a job that had write access
to this repo.

Pinning also gives Dependabot something to open a pull request about, so the
upgrade arrives where the tests run rather than landing unreviewed. The version
stays readable in the trailing comment, which is the half that makes this
maintainable.

The five read-only workflows also get `permissions: contents: read`. Left unset,
a workflow inherits the repository default, and on a repo this old that default
is write — considerably more than a job that checks out and builds needs.

I resolved each SHA from the tag it was already on rather than taking the latest
release, so nothing here is a version bump in disguise. `actions/checkout@v7`
became v7.0.1 because `v7` had nothing more specific to resolve to.

Refs #229
