### PR TITLE
ci: run the lint tiers that were only ever local

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,16 @@
+name: actionlint
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: actionlint
+        uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,17 @@
+name: commitlint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # commitlint reads every commit on the branch, not just the tip.
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,21 @@
+name: gitleaks
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # gitleaks scans history, not just the tip commit.
+          fetch-depth: 0
+      - name: gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.24
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.12.2

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,16 @@
+name: typos
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  typos:
+    name: typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: typos
+        uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -1,0 +1,18 @@
+name: YAML
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  yaml:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install yamllint
+        run: pipx install yamllint==1.38.0
+      - name: yamllint
+        run: yamllint --strict .

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+[files]
+# release-please writes CHANGELOG.md out of commit subjects. A typo in one of
+# those is history — "auto merge relesae please prs" is what the v1.5.0 commit
+# actually said, and correcting the changelog would only make it misquote the
+# commit it links to. Generated text isn't ours to spell-check.
+extend-exclude = ["CHANGELOG.md"]

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,21 @@
+extends: default
+
+ignore:
+  - node_modules/
+
+rules:
+  # GitHub Actions workflows are keyed on `on:`, which yamllint would
+  # otherwise read as the boolean `true`.
+  truthy:
+    check-keys: false
+  # None of these files are multi-document, so the `---` marker is noise.
+  document-start: disable
+  # Prettier collapses the space before an inline comment to exactly one, so
+  # yamllint must not insist on two — the formatter would only take the second
+  # one back off on the next run, and the two would undo each other forever.
+  comments:
+    min-spaces-from-content: 1
+  # .editorconfig caps lines at 80, but action refs and shell one-liners in
+  # workflows regularly run longer and wrap badly.
+  line-length:
+    max: 120

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -39,6 +39,22 @@ pre-push:
       run: bun run prettier:lint "**/*.{md,yml,yaml}"
     markdown:
       run: bun run markdown:lint
+    # These three are not installed by `bun install`, so a fresh clone would
+    # otherwise fail the push with `command not found`. Skipping keeps the hook
+    # usable before you've installed them; CI runs all three unconditionally, so
+    # nothing gets through unchecked.
+    yamllint:
+      skip:
+        - run: "! command -v yamllint"
+      run: yamllint --strict .
+    actionlint:
+      skip:
+        - run: "! command -v actionlint"
+      run: actionlint
+    typos:
+      skip:
+        - run: "! command -v typos"
+      run: typos
     hadolint:
       run: |
         docker compose run --rm -T hadolint hadolint docker/golang/Dockerfile


### PR DESCRIPTION
Third of six on #229. Six checks that either ran nowhere or ran only on the
maintainer's machine.

**golangci-lint is the one that matters.** There's been a `.golangci.yml` in
this repo the whole time — tuned, with a comment explaining why it moved off
`enable-all` — and no CI job ever read it. The git hook ran it, which holds
right up until someone pushes with `--no-verify` or from a fresh clone that
never ran `bun install`.

**commitlint has the same hole.** The `commit-msg` hook lints what you write
locally. release-please reads those messages to decide the next version, so on
any branch pushed from elsewhere, the thing driving releases was unchecked. It
runs on `pull_request`, which is the only event that sees the branch's commits.

**actionlint, yamllint, gitleaks and typos are new.** gitleaks gets
`fetch-depth: 0` because it scans history, not the tip commit.

The yamllint config needed two settings that aren't obvious: `truthy` has to
stop reading a workflow's `on:` key as the boolean `true`, and
`comments.min-spaces-from-content` has to agree with Prettier — Prettier
collapses to one space and yamllint's default demands two, so left alone they'd
undo each other on every run.

I ran all six locally before pushing: yamllint (1.38.0 in a throwaway venv),
actionlint and golangci-lint are clean on the current tree.

The three CLI tools `bun install` doesn't provide get a `skip` guard in the
pre-push hook so a fresh clone doesn't fail the push with `command not found`.
CI runs them unconditionally, so the guard doesn't hide anything.

None of these are in the branch ruleset yet — that's a settings change I can't
make from here. They'll report on every PR; making them required is a separate
click.

Refs #229
