### PR TITLE
ci: lint commits with the commitlint the lockfile pins

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -7,6 +7,8 @@ permissions:
   contents: read
 
 jobs:
+  # Job id is the check name the branch ruleset requires. Renaming it hangs
+  # every open pull request, so it stays `commitlint` and carries no `name:`.
   commitlint:
     runs-on: ubuntu-latest
     steps:
@@ -14,4 +16,23 @@ jobs:
         with:
           # commitlint reads every commit on the branch, not just the tip.
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+      - name: Install bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          # Read from `packageManager` in package.json, so the version is
+          # written down once and CI can't quietly float off it.
+          bun-version-file: package.json
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      # Runs the commitlint pinned in package.json. This was
+      # wagoid/commitlint-github-action, a Docker action carrying its own
+      # commitlint: 19.1.0, two majors behind the 21.2.1 in the lockfile. The
+      # two disagree about body-max-line-length, which 21 doesn't apply to a
+      # line that can't be wrapped, such as a bare URL. So the commit-msg hook
+      # accepted messages CI then rejected, and every dependabot bump with a
+      # long package URL failed here. One version now, and they agree.
+      - name: Lint commit messages
+        run: bunx commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Closes #241

`commitlint` has been failing dependabot's bumps, most recently the
`@biomejs/biome` 2.5.7 → 2.5.8 one in #240. The bump isn't the problem.

The check ran `wagoid/commitlint-github-action`, a Docker action that carries
its own commitlint. That copy is **19.1.0**. `package.json` pins **21.2.1**, and
the lockfile had no say over which one CI used. So the version this repo
actually declares was never the one doing the linting.

The two disagree about `body-max-line-length`: 21 doesn't apply it to a line
that can't be wrapped, such as a bare URL, and 19 does. Dependabot's body opens
with a 110-character line when the package URL is long, which is why this bit
now and not on the last dozen bumps. The `commit-msg` hook accepted the commit,
CI rejected it, and since `commitlint` is a required check the pull request sat
unable to auto-merge.

## What this does

The job installs from the lockfile and runs that commitlint over the pull
request's commit range, the way `Linting` and the other bun jobs already work.
Same `setup-bun` pin, same `--frozen-lockfile`.

Three things it deliberately doesn't do:

- `.commitlintrc.json` is untouched. Still `@commitlint/config-conventional`,
  unextended — no rule overrides.
- No `ignores` for dependabot. Bot commits get linted like everyone else's. The
  first fix I reached for was exempting them, which would have papered over the
  version skew and left it to surface somewhere else later.
- The job id stays `commitlint` and gains no `name:`, so the branch ruleset
  still finds its required check.

## Checked locally

Ran against #240's real commit range with the pinned 21.2.1:

```
bunx commitlint --from <base> --to <head> --verbose
→ 1 warning (footer-leading-blank), exit 0
```

And two deliberately bad commits through the same code path, to be sure this
isn't just switching the check off:

```
✖ subject may not be empty [subject-empty]
✖ type may not be empty [type-empty]
✖ body's lines must not be longer than 100 characters [body-max-line-length]
exit 1
```

That second failure is a plain-prose long line with no URL — still caught.

`actionlint`, `yamllint` and `prettier --check` all pass on the new file. The
`typos` check I couldn't run here: it isn't installed and neither the ghcr image
nor a bunx package would resolve. It'll run on the pipeline.
